### PR TITLE
remove the google form from camps

### DIFF
--- a/app/camps/page.tsx
+++ b/app/camps/page.tsx
@@ -59,7 +59,6 @@ export default function Camps() {
                     </p>
                 </div>
             </div>
-            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfNUWWMK4NuEAqIcFNfEA2x7EmPpUDNy_Pl5JXKauxCsHqhPg/viewform?embedded=true" width="640" height="700">Loading…</iframe>
         </div>
     )
 }


### PR DESCRIPTION
remove the google form as each camp element will link to a sign up google form